### PR TITLE
feat: added multiselect, max_files, checkbox..

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require sushidev/fairu-statamic
 
 ## How to Use
 
-Follow the instructions at https://docs.fairu.app/docs/statamic/get-started to get started.
+Follow the instructions at https://docs.fairu.app/docs/addons/statamic to get started.
 
 ### Add env variables
 
@@ -30,6 +30,8 @@ FAIRU_TENANT_SECRET=[YOUR_API_KEY_SECRET]
 ```
 
 ### Import
+
+If you already have some assets you can run the following command. It will automatically import all the connected assets into your fairu account. Depending on on the amount of files it might take some time.
 
 ```
 php please fairu:setup
@@ -61,13 +63,16 @@ Get just the URL of a file.
 
 **Parameters**
 
-- `id` - The file ID (required)
+- `id` - The file ID (required) 
 - `⁠name` - Custom filename (optional)
 - `⁠width` - Resize image width (optional)
 - `⁠height` - Resize image height (optional)
 - `⁠quality` - Image quality (default: 90)
 - `⁠format` - Convert image format (optional)
 - `⁠focal_point` - Focal point for cropping (optional)
+
+Note that we accept for ID a string or array string.
+Preferable it should be the id of the image. But if you import your files we also accept the previous path which will be transformed into the id.
 
 ### Image Tag
 
@@ -86,6 +91,9 @@ Generate a complete HTML image tag.
 - `⁠class` - CSS class(es) (optional)
 - `⁠alt` - Alt text (optional, falls back to file description)
 
+Note that we accept for ID a string or array string.
+Preferable it should be the id of the image. But if you import your files we also accept the previous path which will be transformed into the id.
+
 ### Responsive Images
 
 Generate a responsive image with srcset and sizes attributes.
@@ -93,6 +101,9 @@ Generate a responsive image with srcset and sizes attributes.
 ```antlers
 {{ fairu:sources id="ID" sources="320:320w,480:800w,768:1200w,1200:1600w,1920:2400w" sizes="100vw" class="responsive-image" alt="Responsive image" }}
 ```
+
+Note that we accept for ID a string or array string.
+Preferable it should be the id of the image. But if you import your files we also accept the previous path which will be transformed into the id.
 
 **Parameters**
 
@@ -104,6 +115,9 @@ Generate a responsive image with srcset and sizes attributes.
 - `⁠height` - Image height attribute (optional)
 - `⁠class` - CSS class(es) (optional)
 - ⁠`alt` - Alt text (optional, falls back to file description)
+
+Note that we accept for ID a string or array string.
+Preferable it should be the id of the image. But if you import your files we also accept the previous path which will be transformed into the id.
 
 ### How the sources parameter works
 
@@ -146,4 +160,4 @@ This powerful combination of ⁠srcset and ⁠sizes ensures optimal image loadin
 
 ### Detailed
 
-Follow the instructions at https://docs.fairu.app/docs/statamic/get-started to find out what you can do.
+Follow the instructions at https://docs.fairu.app/docs/addons/statamic to find out what you can do.

--- a/resources/js/components/Dropzone.vue
+++ b/resources/js/components/Dropzone.vue
@@ -5,7 +5,7 @@
         @dragleave="dragleave"
         @drop="drop">
         <div
-            class="relative"
+            class="relative fa-size-full"
             :class="{ 'pointer-events-none': dragging }">
             <input
                 type="file"
@@ -18,7 +18,7 @@
                 ><i class="inline-block mr-2 material-symbols-outlined">drive_folder_upload</i>
                 <span>Drop files here</span>
             </div>
-            <div class="relative">
+            <div class="relative fa-size-full">
                 <slot></slot>
             </div>
         </div>

--- a/resources/js/components/Fairu.vue
+++ b/resources/js/components/Fairu.vue
@@ -6,7 +6,8 @@
             @selected="handleSelected"
             :multiselect="multiselect"
             :initialAssets="assets"
-            :meta="meta" />
+            :meta="meta"
+            :config="config" />
         <dropzone
             :enabled="canUpload"
             class="border rounded border-slate-400 dark:fa-bg-dark-900 fa-overflow-hidden fa-bg-slate-100 dark:fa-border-zinc-900 dark:fa-bg-zinc-800"
@@ -17,14 +18,14 @@
                     type="file"
                     ref="upload"
                     @change="handleUpload" />
-                <div>
-                    <div class="flex flex-wrap items-center p-3 gap-x-4">
-                        <button
-                            @click="openSearch()"
-                            class="btn"
-                            ><i class="inline-block mr-2 material-symbols-outlined">drive_folder_upload</i>
-                            {{ __('fairu::fieldtype.search') }}
-                        </button>
+                <div class="flex flex-wrap items-center p-3 gap-x-4">
+                    <button
+                        @click="openSearch()"
+                        class="btn"
+                        ><i class="inline-block mr-2 material-symbols-outlined">drive_folder_upload</i>
+                        {{ __('fairu::fieldtype.search') }}
+                    </button>
+                    <div>
                         <p class="flex-1 text-xs">
                             <button
                                 type="button"
@@ -55,11 +56,26 @@
                     size="24"
                     v-if="loading || uploading" />
                 <span v-if="uploading">{{ percentUploaded }}%</span>
-                <div class="w-full">
+                <div
+                    class="w-full"
+                    v-if="!loading && !uploading">
                     <div
-                        v-if="!loading && !uploading"
+                        class="text-xs fa-divide-x fa-divide-gray-200 fa-text-gray-400 dark:fa-divide-zinc-700 dark:fa-text-zinc-500"
+                        v-if="(config.max_files && config.max_files !== 1) || config.min_files"
+                        ><span
+                            class="fa-pr-2"
+                            v-if="config.min_files"
+                            >Min: {{ config.min_files }}</span
+                        ><span
+                            class="fa-pl-2 first:fa-pl-0"
+                            v-if="config.max_files"
+                            >Max: {{ config.max_files }}</span
+                        ></div
+                    >
+                    <div
                         class="grid w-full min-w-0 gap-2 items-center fa-mt-2 fa-grid-cols-[auto,1fr,auto] fa-border-t fa-border-zinc-200 fa-pt-2 first:fa-mt-0 first:fa-border-none first:fa-pt-0 dark:fa-border-zinc-700"
-                        v-for="(item, index) in assets">
+                        v-for="(item, index) in assets"
+                        v-key="item.id + index">
                         <img
                             ref="fileImage"
                             v-if="loading == false && !fetchingMetaData && item?.mime.startsWith('image/')"
@@ -79,7 +95,7 @@
                         <div class="flex items-center gap-1">
                             <a
                                 @click.stop
-                                :href="item?.edit_url"
+                                :href="meta.file + '/' + item?.id"
                                 target="_blank"
                                 title="Open in Fairu"
                                 class="flex items-center text-xs cursor-pointer hover:text-blue !fa-text-gray-300 dark:!fa-text-zinc-500"

--- a/resources/js/components/FairuBrowser.vue
+++ b/resources/js/components/FairuBrowser.vue
@@ -2,8 +2,7 @@
     <stack @closed="emitClose">
         <div
             slot-scope="{ close }"
-            class="grid h-full bg-white dark:bg-dark-800"
-            style="grid-template-rows: auto 1fr auto">
+            class="grid h-full bg-white dark:bg-dark-800 fa-grid-rows-[auto,auto,1fr,auto]">
             <section>
                 <input
                     class="hidden"
@@ -11,9 +10,36 @@
                     ref="upload"
                     @change="handleFileChange" />
                 <div class="flex gap-2 p-2 bg-white dark:bg-dark-800 data-list-border justify-stretch">
+                    <div
+                        v-if="createFolderInputVisible"
+                        class="flex flex-grow gap-1">
+                        <input
+                            class="h-8 input-text"
+                            type="text"
+                            ref="newfolder"
+                            :placeholder="__('fairu::browser.new_folder_name')"
+                            v-model="newFolderName" />
+                        <button
+                            class="flex items-center gap-1 btn btn-primary btn-sm"
+                            @click="handleCreateFolder">
+                            <span>Erstellen</span>
+                        </button>
+                        <button
+                            class="flex items-center gap-1 btn btn-sm"
+                            @click="closeCreateFolder">
+                            <span>{{ __('fairu::browser.cancel') }}</span>
+                        </button>
+                    </div>
+                    <input
+                        v-if="!createFolderInputVisible"
+                        class="h-8 input-text"
+                        type="text"
+                        ref="search"
+                        :placeholder="__('fairu::browser.search_in_folder')"
+                        @input="handleSearchInput" />
                     <button
                         type="button"
-                        class="flex items-center gap-1 text-base btn btn-primary"
+                        class="flex items-center gap-1 btn btn-sm"
                         @click="openFile(folder)"
                         v-if="!createFolderInputVisible">
                         <i class="text-gray-700 material-symbols-outlined">upload</i>
@@ -21,59 +47,23 @@
                     </button>
                     <button
                         href="#"
-                        class="flex items-center gap-1 text-base btn"
+                        class="flex items-center gap-1 btn btn-sm"
                         @click="openCreateFolder"
                         v-if="!createFolderInputVisible">
                         <i class="text-gray-700 material-symbols-outlined">create_new_folder</i>
                         <span>{{ __('fairu::browser.new_folder') }}</span>
                     </button>
-                    <div
-                        v-if="createFolderInputVisible"
-                        class="flex flex-grow gap-1">
-                        <input
-                            class="input-text"
-                            type="text"
-                            ref="newfolder"
-                            :placeholder="__('fairu::browser.new_folder_name')"
-                            v-model="newFolderName" />
-                        <button
-                            class="flex items-center gap-1 text-base btn btn-primary"
-                            @click="handleCreateFolder">
-                            <i class="text-lg text-gray-700 material-symbols-outlined">check_circle</i
-                            ><span>Erstellen</span>
-                        </button>
-                        <button
-                            class="flex items-center gap-1 text-base btn"
-                            @click="closeCreateFolder">
-                            <i class="text-lg text-gray-700 material-symbols-outlined">cancel</i
-                            ><span>{{ __('fairu::browser.cancel') }}</span>
-                        </button>
-                    </div>
-                    <input
-                        v-if="!createFolderInputVisible"
-                        class="input-text"
-                        type="text"
-                        ref="search"
-                        :placeholder="__('fairu::browser.search_in_folder')"
-                        @input="handleSearchInput" />
-                    <a
-                        :href="`${meta.folder}${folder != null ? '/' + folder : ''}`"
-                        target="_blank"
-                        class="flex items-center gap-1 text-base btn"
-                        v-if="!createFolderInputVisible">
-                        <i class="text-gray-700 material-symbols-outlined">open_in_new</i>
-                    </a>
-                    <a
-                        class="flex items-center gap-1 text-sm text-gray-700 link"
-                        @click.prevent="close">
-                        <i class="text-xl material-symbols-outlined">close</i>
-                    </a>
                 </div>
+            </section>
+            <section
+                class="grid items-center w-full fa-border-y fa-border-gray-200 fa-bg-gray-50 fa-px-3 fa-py-2 fa-text-gray-600 dark:fa-border-zinc-700 dark:fa-bg-zinc-800 dark:fa-text-zinc-400"
+                v-if="multiselect">
+                <div class="text-xs">{{ assets?.length + ' ' + __('fairu::browser.entries_selected') }}</div>
             </section>
             <dropzone
                 :enabled="canUpload"
                 @dropped="handleFileDrop"
-                class="overflow-y-auto">
+                class="relative overflow-y-auto size-full">
                 <div
                     v-if="loadingList"
                     class="grid items-center justify-center w-full h-full p-8">
@@ -85,94 +75,37 @@
                 </div>
                 <div v-show="!loadingList">
                     <div
-                        class="px-2 data-list-border"
+                        class="px-2 group last:fa-border-b-none fa-border-b fa-border-slate-100 hover:fa-bg-gray-50 dark:fa-border-zinc-700 dark:hover:fa-bg-zinc-700"
                         v-if="folder">
                         <a
                             href="#"
-                            class="flex items-center gap-1 px-2 py-1"
-                            style="min-height: 3rem"
+                            class="flex items-center gap-1 px-2 py-1 fa-min-h-12"
                             @click="selectFolder(folderParent)">
-                            <i class="text-gray-700 material-symbols-outlined">folder</i> ...
+                            <i class="text-gray-700 material-symbols-outlined fa-px-1 fa-text-2xl">folder</i> ...
                         </a>
                     </div>
                     <div
                         v-for="(item, index) in folderContent?.data"
                         v-key="item?.id"
-                        class="px-2 data-list-border">
+                        class="px-2 group last:fa-border-b-none fa-border-b fa-border-slate-100 hover:fa-bg-gray-50 dark:fa-border-zinc-700 dark:hover:fa-bg-zinc-700">
                         <button
-                            v-if="item.type == 'folder'"
-                            class="flex items-center gap-1 px-2 py-1"
-                            style="min-height: 3rem"
+                            v-if="item.type === 'folder'"
+                            class="flex items-center w-full gap-1 px-2 py-1 text-sm fa-min-h-12"
                             @click="selectFolder(item.id)">
-                            <i class="text-gray-700 material-symbols-outlined">folder</i> {{ item.name }}
+                            <i class="text-gray-700 material-symbols-outlined fa-px-1 fa-text-2xl">folder</i>
+                            {{ item.name }}
                         </button>
-                        <div
-                            class="grid items-center gap-2 px-2 py-1"
-                            style="min-height: 3rem; grid-template-columns: 1fr auto"
-                            v-if="item.type !== 'folder'">
-                            <button
-                                type="button"
-                                class="flex w-full gap-1 cursor-pointer grow"
-                                @click.prevent="selectItem(item)">
-                                <div
-                                    class="flex items-center justify-center flex-none overflow-hidden bg-gray-300 rounded-full"
-                                    style="width: 34px; height: 34px">
-                                    <img
-                                        v-if="proxyUrl && item?.blocked != true && item?.mime?.startsWith('image/')"
-                                        :src="`${proxyUrl}/${item.id}/thumbnail.webp?width=34&height=34`"
-                                        class="object-cover" />
-                                    <span
-                                        class="block text-gray-600"
-                                        style="font-size: 8px"
-                                        v-if="item?.mime?.startsWith('image/') == false">
-                                        {{ getExtension(item.mime) }}
-                                    </span>
-                                </div>
-                                <div class="flex items-center gap-2 text-sm grow"> {{ item.name }} </div>
-                            </button>
-                            <div class="flex gap-1">
-                                <a
-                                    :href="`${meta.file}${item.id}`"
-                                    target="_blank"
-                                    :title="__('fairu::browser.edit_in_fairu')"
-                                    class="flex gap-1 text-xs cursor-pointer"
-                                    ><i class="text-xl text-gray-300 material-symbols-outlined">edit</i>
-                                </a>
-                            </div>
-                        </div>
+                        <browser-list-item
+                            :asset="item"
+                            :meta="meta"
+                            :selected="isSelected(item)"
+                            :multiselect="multiselect"
+                            @change="multiselect ? toggleItemSelection(item) : selectItem(item)"
+                            v-if="item.type !== 'folder'" />
                     </div>
                 </div>
-            </dropzone>
-            <div class="flex flex-wrap justify-between gap-4 px-4 py-2 border-t border-gray-100 dark:border-dark-600">
-                <div class="flex items-center justify-end gap-1 -mt-px">
-                    <button
-                        :disabled="page <= 1"
-                        @click.prevent="goToPage(1)"
-                        class="flex items-center gap-1 text-base btn btn-sm">
-                        <i class="text-xl text-dark-800 dark:text-gray-300 material-symbols-outlined">first_page</i>
-                    </button>
-                    <button
-                        :disabled="page <= 1"
-                        @click.prevent="previousPage"
-                        class="flex items-center gap-1 text-base btn btn-sm">
-                        {{ __('fairu::browser.previous') }}
-                    </button>
-                    <div class="px-2">{{ page }} / {{ lastPage || 1 }}</div>
-                    <button
-                        :disabled="page >= lastPage"
-                        @click.prevent="nextPage"
-                        class="flex items-center gap-1 text-base btn btn-sm">
-                        {{ __('fairu::browser.next') }}
-                    </button>
-                    <button
-                        :disabled="page >= lastPage"
-                        @click.prevent="goToPage(lastPage)"
-                        class="flex items-center gap-1 text-base btn btn-sm">
-                        <i class="text-xl text-gray-300 material-symbols-outlined">last_page</i>
-                    </button>
-                </div>
                 <a
-                    class="flex items-center gap-1 text-2xs"
+                    class="absolute bottom-0 left-0 flex items-center gap-1 p-3 text-2xs"
                     href="https://fairu.app"
                     style="color: #666">
                     <span
@@ -185,6 +118,50 @@
                         src="../../svg/fairu-logo.svg"
                         alt="Fairu Asset Service" />
                 </a>
+            </dropzone>
+            <div
+                class="flex flex-wrap justify-between gap-4 px-3 py-3 border-t border-gray-100 dark:border-dark-600 dark:bg-dark-900 fa-bg-slate-50">
+                <div class="flex items-center justify-end gap-1 -mt-px">
+                    <button
+                        :disabled="page <= 1"
+                        @click.prevent="goToPage(1)"
+                        class="flex items-center gap-1 btn btn-sm">
+                        <i class="dark:text-gray-300 material-symbols-outlined">first_page</i>
+                    </button>
+                    <button
+                        :disabled="page <= 1"
+                        @click.prevent="previousPage"
+                        class="flex items-center gap-1 btn btn-sm">
+                        {{ __('fairu::browser.previous') }}
+                    </button>
+                    <div class="px-2 text-sm">{{ page }} / {{ lastPage || 1 }}</div>
+                    <button
+                        :disabled="page >= lastPage"
+                        @click.prevent="nextPage"
+                        class="flex items-center gap-1 btn btn-sm">
+                        {{ __('fairu::browser.next') }}
+                    </button>
+                    <button
+                        :disabled="page >= lastPage"
+                        @click.prevent="goToPage(lastPage)"
+                        class="flex items-center gap-1 btn btn-sm">
+                        <i class="text-gray-300 material-symbols-outlined">last_page</i>
+                    </button>
+                </div>
+                <div class="flex gap-3">
+                    <button
+                        class="flex items-center gap-1 btn"
+                        @click="close"
+                        v-if="!createFolderInputVisible">
+                        <span>{{ __('fairu::browser.cancel') }}</span>
+                    </button>
+                    <button
+                        class="flex items-center gap-1 btn btn-primary"
+                        @click="sendSelection"
+                        v-if="!createFolderInputVisible">
+                        <span>{{ __('fairu::browser.select') }}</span>
+                    </button>
+                </div>
             </div>
         </div>
     </stack>
@@ -193,6 +170,7 @@
 <script>
 import { RingLoader } from 'vue-spinners-css';
 import Dropzone from './Dropzone.vue';
+import BrowserListItem from './browser/BrowserListItem.vue';
 import { fairuLoadFolder, fairuUpload } from '../utils/fetches';
 import axios from 'axios';
 
@@ -202,11 +180,12 @@ export default {
     components: {
         RingLoader,
         Dropzone,
+        BrowserListItem,
     },
 
     data() {
         return {
-            asset: null,
+            assets: [],
             loading: false,
             folder: null,
             page: 1,
@@ -219,18 +198,13 @@ export default {
         };
     },
     props: {
-        proxyUrl: String,
+        meta: null,
+        initialAssets: [],
+        multiselect: Boolean,
     },
     methods: {
         emitClose() {
             this.$emit('close');
-        },
-        getExtension(mime) {
-            const parts = mime.split('/');
-            if (parts.length == 2) {
-                return parts[1];
-            }
-            return 'n/a';
         },
         openFile() {
             this.$refs.upload.value = null;
@@ -250,11 +224,28 @@ export default {
             this.$refs.search.value = null;
         },
         selectItem(asset) {
-            this.asset = asset;
-            this.$emit('selected', this.asset);
+            this.$emit('selected', asset);
             this.$nextTick(() => {
                 this.emitClose();
             });
+        },
+        sendSelection() {
+            this.$emit('selected', this.assets);
+            this.$nextTick(() => {
+                this.emitClose();
+            });
+        },
+        toggleItemSelection(asset) {
+            console.log({ asset });
+            console.log({ assets: this.assets });
+            if (this.assets.find((e) => e?.id === asset.id)) {
+                this.assets = this.assets.filter((e) => e?.id !== asset.id);
+            } else {
+                this.assets.push(asset);
+            }
+        },
+        isSelected(asset) {
+            return this.assets.findIndex((e) => e?.id === asset.id) > -1;
         },
         handleFileChange(evt) {
             const file = evt.target.files[0];
@@ -278,11 +269,18 @@ export default {
                 this.$progress.complete('upload' + this._uid);
                 this.$toast.success('Datei erfolgreich hochgeladen.');
                 this.fetchingMetaData = true;
-                this.$nextTick(async () => {
-                    await this.loadMetaData(result?.data?.id);
-                    this.selectItem(this.asset);
+                setTimeout(async () => {
+                    const fetchedAsset = await this.loadMetaData(result?.data?.id);
+                    console.log({ fetchedAsset });
+                    if (this.multiselect) {
+                        // this.folderContent?.unshift(fetchedAsset);
+                        await this.loadFolder();
+                        this.assets.push(fetchedAsset);
+                    } else {
+                        this.selectItem(this.asset);
+                    }
                     this.fetchingMetaData = false;
-                });
+                }, 200);
             };
             this.$progress.start('upload' + this._uid);
             this.percentUploaded = 0;
@@ -336,11 +334,11 @@ export default {
             this.page = page;
             this.loadFolder(this.$refs.search.value);
         },
-        loadFolder(search, folder = null) {
+        async loadFolder(search, folder = null) {
             this.folder = folder ?? this.folder;
             this.loadingList = true;
 
-            fairuLoadFolder({
+            await fairuLoadFolder({
                 page: this.page,
                 folder: this.folder,
                 search: search ?? null,
@@ -359,17 +357,15 @@ export default {
             });
         },
         async loadMetaData(id) {
-            if (!id && !this.asset?.id) return;
+            if (!id && !this.assets) return;
             this.loading = true;
             await axios
-                .get('/fairu/files/' + (id ?? this.asset?.id))
+                .get('/fairu/files/' + id)
                 .then((result) => {
-                    this.asset = result.data.data;
-                    this.folder = result.data.parent_id;
                     this.loading = false;
+                    return result.data.data;
                 })
                 .catch((err) => {
-                    this.asset = null;
                     this.loading = false;
                     this.$toast.error(err.response.data.message);
                 });
@@ -395,11 +391,12 @@ export default {
 
     computed: {
         url() {
-            return this.proxyUrl + '/' + this.asset?.id + '/thumbnail.webp?width=50&height=50';
+            return this.meta.proxy + '/' + this.asset?.id + '/thumbnail.webp?width=50&height=50';
         },
     },
 
     mounted() {
+        this.assets = this.initialAssets;
         this.loadFolder();
     },
     beforeDestroy() {

--- a/resources/js/components/browser/BrowserListItem.vue
+++ b/resources/js/components/browser/BrowserListItem.vue
@@ -1,0 +1,72 @@
+<template>
+    <div
+        class="grid items-center gap-2 px-2 py-1 fa-min-h-12 fa-grid-cols-[1fr,auto]"
+        @click="toggleSelection"
+        v-if="asset.type !== 'folder'">
+        <div class="flex items-center w-full gap-1 cursor-pointer grow">
+            <input-checkbox
+                v-if="multiselect"
+                class="fa-mr-1.5"
+                :id="asset?.id"
+                :checked="selected" />
+            <div class="flex items-center justify-center flex-none overflow-hidden bg-gray-300 rounded-full fa-size-8">
+                <img
+                    v-if="meta.proxy && asset?.blocked != true && asset?.mime?.startsWith('image/')"
+                    :src="`${meta.proxy}/${asset.id}/thumbnail.webp?width=34&height=34`"
+                    class="object-cover" />
+                <span
+                    class="block text-gray-600"
+                    style="font-size: 8px"
+                    v-if="asset?.mime?.startsWith('image/') == false">
+                    {{ getExtension(asset.mime) }}
+                </span>
+            </div>
+            <div class="flex items-center gap-2 text-sm grow"> {{ asset.name }} </div>
+        </div>
+        <div class="flex gap-1">
+            <a
+                @click.stop
+                :href="asset.edit_url"
+                target="_blank"
+                :title="__('fairu::browser.edit_in_fairu')"
+                class="flex gap-1 text-xs cursor-pointer"
+                ><i
+                    class="text-lg text-gray-300 material-symbols-outlined dark:!fa-text-gray-600 dark:hover:!fa-text-blue-500"
+                    >open_in_new</i
+                >
+            </a>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    components: {},
+
+    data() {
+        return {};
+    },
+    props: {
+        asset: null,
+        meta: null,
+        selected: Boolean,
+        multiselect: Boolean,
+    },
+    methods: {
+        toggleSelection() {
+            this.$emit('change', { asset: this.asset, selected: !this.selected });
+        },
+        getExtension(mime) {
+            const parts = mime.split('/');
+            if (parts.length == 2) {
+                return parts[1];
+            }
+            return 'n/a';
+        },
+    },
+
+    computed: {},
+
+    mounted() {},
+};
+</script>

--- a/resources/js/components/browser/BrowserListItem.vue
+++ b/resources/js/components/browser/BrowserListItem.vue
@@ -1,6 +1,7 @@
 <template>
     <div
-        class="grid items-center gap-2 px-2 py-1 fa-min-h-12 fa-grid-cols-[1fr,auto]"
+        class="grid items-center gap-2 px-2 py-1 fa-min-h-12 fa-select-none fa-grid-cols-[1fr,auto]"
+        :class="disabled ? 'fa-opacity-50' : ''"
         @click="toggleSelection"
         v-if="asset.type !== 'folder'">
         <div class="flex items-center w-full gap-1 cursor-pointer grow">
@@ -26,12 +27,12 @@
         <div class="flex gap-1">
             <a
                 @click.stop
-                :href="asset.edit_url"
+                :href="meta.file + '/' + asset.id"
                 target="_blank"
                 :title="__('fairu::browser.edit_in_fairu')"
                 class="flex gap-1 text-xs cursor-pointer"
                 ><i
-                    class="text-lg text-gray-300 material-symbols-outlined dark:!fa-text-gray-600 dark:hover:!fa-text-blue-500"
+                    class="text-lg text-gray-300 material-symbols-outlined fa-pointer-events-none dark:!fa-text-gray-600 dark:hover:!fa-text-blue-500"
                     >open_in_new</i
                 >
             </a>
@@ -51,9 +52,11 @@ export default {
         meta: null,
         selected: Boolean,
         multiselect: Boolean,
+        disabled: Boolean,
     },
     methods: {
         toggleSelection() {
+            if (this.disabled) return;
             this.$emit('change', { asset: this.asset, selected: !this.selected });
         },
         getExtension(mime) {

--- a/resources/js/components/fieldtypes/Fairu.vue
+++ b/resources/js/components/fieldtypes/Fairu.vue
@@ -30,7 +30,7 @@
                             <button
                                 type="button"
                                 class="underline text-blue"
-                                @click="openFile(null)">
+                                @click="openFile">
                                 {{ __('fairu::fieldtype.upload_file') }}
                             </button>
                             <span class="fa-ml-1.5 fa-text-gray-500">{{
@@ -118,9 +118,9 @@
 <script>
 import axios from 'axios';
 import { RingLoader } from 'vue-spinners-css';
-import FairuBrowser from './FairuBrowser.vue';
-import Dropzone from './Dropzone.vue';
-import { fairuUpload } from '../utils/fetches';
+import FairuBrowser from '../FairuBrowser.vue';
+import Dropzone from '../Dropzone.vue';
+import { fairuUpload } from '../../utils/fetches';
 
 export default {
     mixins: [Fieldtype],
@@ -155,8 +155,7 @@ export default {
             }
             return 'n/a';
         },
-        openFile(setFolderTo) {
-            this.uploadFolder = setFolderTo ?? null;
+        openFile() {
             this.$refs.upload.value = null;
             this.$refs.upload.click();
         },
@@ -214,7 +213,7 @@ export default {
 
             fairuUpload({
                 file,
-                folder: this.uploadFolder != null ? this.uploadFolder : null,
+                folder: this.config.folder ?? null,
                 onUploadProgressCallback: (progressEvent) => {
                     this.percentUploaded = Math.round((progressEvent.loaded * 100) / progressEvent.total);
                 },
@@ -223,7 +222,7 @@ export default {
             });
         },
         sendUpdate() {
-            this.update(this.multiselect ? this.assets?.map((e) => e.id) : this.assets[0]?.id);
+            this.update(this.assets?.map((e) => e.id));
         },
         async loadMetaData(ids) {
             let assetIds = [];

--- a/resources/js/components/fieldtypes/FolderSelector.vue
+++ b/resources/js/components/fieldtypes/FolderSelector.vue
@@ -1,0 +1,80 @@
+<template>
+    <div class="fa-grid fa-grid-cols-[1fr,auto]">
+        <ring-loader
+            color="#4a4a4a"
+            class="w-5 h-5"
+            size="24"
+            v-if="loading" />
+        <div v-else>
+            <div
+                class="text-sm"
+                v-if="folder"
+                >{{ folder?.name }}</div
+            >
+            <button
+                class="text-sm text-blue"
+                @click="searchOpen = true"
+                v-text="!!folder ? 'Change folder' : 'Select folder'"></button>
+        </div>
+        <div>
+            <button @click="handleSelected(null)"
+                ><i
+                    class="text-lg material-symbols-outlined fa-pointer-events-none dark:!fa-text-white dark:hover:!fa-text-blue-500"
+                    >close</i
+                ></button
+            >
+        </div>
+        <fairu-browser
+            v-if="searchOpen"
+            @close="searchOpen = false"
+            @selected="handleSelected"
+            :multiselect="multiselect"
+            :initialAssets="assets"
+            :meta="meta"
+            selectionType="folder"
+            :config="config" />
+    </div>
+</template>
+
+<script>
+import FairuBrowser from '../FairuBrowser.vue';
+import { fairuGetFolder } from '../../utils/fetches';
+
+export default {
+    mixins: [Fieldtype],
+
+    components: {
+        FairuBrowser,
+    },
+    props: {
+        initialFolder: String,
+    },
+
+    data() {
+        return {
+            folder: null,
+            searchOpen: false,
+            loading: true,
+        };
+    },
+
+    methods: {
+        handleSelected(folder) {
+            this.folder = folder;
+            console.log(folder);
+            this.update(folder?.id);
+        },
+    },
+    async mounted() {
+        if (this.value) {
+            await fairuGetFolder({
+                folder: this.value,
+                successCallback: (res) => {
+                    this.folder = res?.data?.entry;
+                },
+            });
+        }
+        this.loading = false;
+    },
+};
+</script>

--- a/resources/js/components/fieldtypes/FolderSelector.vue
+++ b/resources/js/components/fieldtypes/FolderSelector.vue
@@ -14,7 +14,9 @@
             <button
                 class="text-sm text-blue"
                 @click="searchOpen = true"
-                v-text="!!folder ? 'Change folder' : 'Select folder'"></button>
+                v-text="
+                    !!folder ? __('fairu::folderselect.change_folder') : __('fairu::folderselect.select_folder')
+                "></button>
         </div>
         <div>
             <button @click="handleSelected(null)"
@@ -61,7 +63,6 @@ export default {
     methods: {
         handleSelected(folder) {
             this.folder = folder;
-            console.log(folder);
             this.update(folder?.id);
         },
     },

--- a/resources/js/components/input/InputCheckbox.vue
+++ b/resources/js/components/input/InputCheckbox.vue
@@ -6,6 +6,7 @@
                 :name="id"
                 type="checkbox"
                 :checked="checked"
+                @change="emitChange"
                 :disabled="disabled"
                 class="fa-col-start-1 fa-row-start-1 fa-appearance-none fa-rounded fa-border fa-border-gray-300 fa-bg-white checked:fa-border-blue-600 checked:fa-bg-blue-600 indeterminate:fa-border-blue-600 indeterminate:fa-bg-blue-600 focus-visible:fa-outline focus-visible:fa-outline-2 focus-visible:fa-outline-offset-2 focus-visible:fa-outline-blue-600 disabled:fa-border-gray-300 disabled:fa-bg-gray-100 disabled:checked:fa-bg-gray-100 dark:fa-border-zinc-600 dark:fa-bg-zinc-700 forced-colors:fa-appearance-auto" />
             <svg

--- a/resources/js/components/input/InputCheckbox.vue
+++ b/resources/js/components/input/InputCheckbox.vue
@@ -1,0 +1,67 @@
+<template>
+    <div class="fa-flex fa-h-6 fa-shrink-0 fa-items-center">
+        <div class="fa-group fa-grid fa-size-4 fa-grid-cols-1">
+            <input
+                :id="id"
+                :name="id"
+                type="checkbox"
+                :checked="checked"
+                :disabled="disabled"
+                class="fa-col-start-1 fa-row-start-1 fa-appearance-none fa-rounded fa-border fa-border-gray-300 fa-bg-white checked:fa-border-blue-600 checked:fa-bg-blue-600 indeterminate:fa-border-blue-600 indeterminate:fa-bg-blue-600 focus-visible:fa-outline focus-visible:fa-outline-2 focus-visible:fa-outline-offset-2 focus-visible:fa-outline-blue-600 disabled:fa-border-gray-300 disabled:fa-bg-gray-100 disabled:checked:fa-bg-gray-100 dark:fa-border-zinc-600 dark:fa-bg-zinc-700 forced-colors:fa-appearance-auto" />
+            <svg
+                class="fa-pointer-events-none fa-col-start-1 fa-row-start-1 fa-size-3.5 fa-self-center fa-justify-self-center fa-stroke-white group-has-[:disabled]:fa-stroke-gray-950/25"
+                viewBox="0 0 14 14"
+                fill="none">
+                <path
+                    class="fa-opacity-0 group-has-[:checked]:fa-opacity-100"
+                    d="M3 8L6 11L11 3.5"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round" />
+                <path
+                    class="fa-opacity-0 group-has-[:indeterminate]:fa-opacity-100"
+                    d="M3 7H11"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round" />
+            </svg>
+        </div>
+        <div
+            class="fa-min-w-0 fa-flex-1 fa-text-sm/6"
+            v-if="label">
+            <label
+                :for="id"
+                class="font-medium fa-select-none fa-text-gray-900"
+                >{{ label }}</label
+            >
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    components: {},
+
+    data() {
+        return {};
+    },
+    props: {
+        id: String,
+        label: String,
+        checked: Boolean,
+        disabled: {
+            type: Object,
+            default: () => false,
+        },
+    },
+    methods: {
+        emitChange() {
+            this.$emit('change', !this.checked);
+        },
+    },
+
+    computed: {},
+
+    mounted() {},
+};
+</script>

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,7 +1,11 @@
 import FairuFieldtype from './components/Fairu.vue';
 import FairuBrowser from './components/FairuBrowser.vue';
+import BrowserListItem from './components/browser/BrowserListItem.vue';
 import Dropzone from './components/Dropzone.vue';
+import InputCheckbox from './components/input/InputCheckbox.vue';
 
 Statamic.$components.register('fairu-fieldtype', FairuFieldtype);
 Statamic.$components.register('fairu-browser', FairuBrowser);
+Statamic.$components.register('browser-list-item', BrowserListItem);
 Statamic.$components.register('dropzone', Dropzone);
+Statamic.$components.register('input-checkbox', InputCheckbox);

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,11 +1,16 @@
-import FairuFieldtype from './components/Fairu.vue';
+import FairuFieldtype from './components/fieldtypes/Fairu.vue';
 import FairuBrowser from './components/FairuBrowser.vue';
 import BrowserListItem from './components/browser/BrowserListItem.vue';
 import Dropzone from './components/Dropzone.vue';
 import InputCheckbox from './components/input/InputCheckbox.vue';
+import FolderSelector from './components/fieldtypes/FolderSelector.vue';
 
 Statamic.$components.register('fairu-fieldtype', FairuFieldtype);
 Statamic.$components.register('fairu-browser', FairuBrowser);
 Statamic.$components.register('browser-list-item', BrowserListItem);
 Statamic.$components.register('dropzone', Dropzone);
 Statamic.$components.register('input-checkbox', InputCheckbox);
+
+Statamic.booting(() => {
+    Statamic.component('folder_selector-fieldtype', FolderSelector);
+});

--- a/resources/js/utils/fetches.js
+++ b/resources/js/utils/fetches.js
@@ -1,5 +1,17 @@
 import axios from 'axios';
 
+export const fairuGetFolder = async ({ folder, successCallback, errorCallback }) => {
+    await axios
+        .get(`/fairu/folders/${folder}`)
+        .then((result) => {
+            !!successCallback && successCallback(result);
+        })
+        .catch((err) => {
+            console.error(err);
+            !!errorCallback && errorCallback(err);
+        });
+};
+
 export const fairuLoadFolder = async ({ page, folder, search = null, successCallback, errorCallback }) => {
     await axios
         .post('/fairu/folders', {

--- a/resources/js/utils/fetches.js
+++ b/resources/js/utils/fetches.js
@@ -28,31 +28,57 @@ export const fairuLoadFolder = async ({ page, folder, search = null, successCall
         });
 };
 
-export const fairuUpload = ({ file, folder, onUploadProgressCallback, errorCallback, successCallback }) => {
+export const fairuUpload = async ({
+    files,
+    folder,
+    onUploadProgressCallback = () => {},
+    errorCallback,
+    successCallback,
+}) => {
+    const filesArray = files ? Array.from(files) : [];
+
     axios
-        .post('/fairu/upload', {
-            filename: file.name,
-            mime: file.type,
+        .post('/fairu/upload-multiple', {
+            files: filesArray?.map((file) => file.name),
             folder,
         })
         .then(async (result) => {
-            await axios
-                .put(result.data.upload_url, file, {
-                    headers: {
-                        'x-amz-acl': 'public-read',
-                        'Content-Type': file.type?.toString(),
-                    },
-                    onUploadProgress: onUploadProgressCallback,
-                })
-                .then(async (resultUpload) => {
-                    await axios.get(result.data.sync_url).then((resultSync) => {
-                        successCallback(resultSync);
-                    });
-                })
-                .catch((err) => {
+            let counter = 0;
+
+            result?.data?.forEach(async (entry, index) => {
+                try {
+                    let resultUpload = await axios.put(
+                        entry.storage_upload_path ? entry.storage_upload_path.toString() : '/',
+                        filesArray ? filesArray[index] : null,
+                        {
+                            headers: {
+                                'x-amz-acl': 'public-read',
+                                'Content-Type': entry.mime_type?.toString(),
+                            },
+                            onUploadProgress: onUploadProgressCallback,
+                        },
+                    );
+
+                    counter++;
+
+                    if (counter == result.data.length) {
+                        const resultMeta = await axios.post('/fairu/upload-meta-bulk', {
+                            files: result?.data.map((entry) => {
+                                return {
+                                    path: entry.storage_path,
+                                    name: entry.filename,
+                                    parent_id: folder,
+                                    fingerprint: entry.fingerprint?.toString(),
+                                };
+                            }),
+                        });
+                        !!successCallback && successCallback(resultMeta);
+                    }
+                } catch (err) {
                     console.error(err);
                     !!errorCallback && errorCallback(err);
-                });
+                }
+            });
         })
         .catch((err) => {
             console.error(err);

--- a/resources/js/utils/fetches.js
+++ b/resources/js/utils/fetches.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-export const fairuLoadFolder = ({ page, folder, search = null, successCallback, errorCallback }) => {
-    axios
+export const fairuLoadFolder = async ({ page, folder, search = null, successCallback, errorCallback }) => {
+    await axios
         .post('/fairu/folders', {
             page,
             folder,

--- a/resources/lang/de/browser.php
+++ b/resources/lang/de/browser.php
@@ -2,10 +2,12 @@
 return [
     "cancel" => "Abbrechen",
     "edit_in_fairu" => "In Fairu bearbeiten",
+    "entries_selected" => "Einträge ausgewählt",
     "new_folder" => "Neuer Ordner",
     "new_folder_name" => "Neuer Ordnername",
     "next" => "Weiter",
     "previous" => "Zurück",
     "search_in_folder" => "Suche in Ordner",
+    "select" => "Auswählen",
     "upload" => "Hochladen"
 ];

--- a/resources/lang/de/browser.php
+++ b/resources/lang/de/browser.php
@@ -1,11 +1,16 @@
 <?php
 return [
     "cancel" => "Abbrechen",
+    "clear_selection" => "Auswahl leeren",
+    "create" => "Erstellen",
     "edit_in_fairu" => "In Fairu bearbeiten",
     "entries_selected" => "Einträge ausgewählt",
+    "errors" => ["error_fetching_files" => "Fehler beim Laden der Dateien"],
+    "files_uploaded_successfully" => "Dateien erfolgreich hochgeladen.",
     "new_folder" => "Neuer Ordner",
     "new_folder_name" => "Neuer Ordnername",
     "next" => "Weiter",
+    "only_selection" => "Nur Auswahl",
     "previous" => "Zurück",
     "search_in_folder" => "Suche in Ordner",
     "select" => "Auswählen",

--- a/resources/lang/de/fieldtype.php
+++ b/resources/lang/de/fieldtype.php
@@ -1,8 +1,11 @@
 <?php
 return [
     "change" => "Ändern",
+    "delete" => "Löschen",
     "meta_data_fetching" => "Metadaten werden ermittelt",
+    "open_in_fairu" => "In Fairu öffnen",
     "or_add_per_drag_and_drop" => "oder per Drag & Drop hierher ziehen.",
+    "rules" => ["max" => "Max", "min" => "Min"],
     "search" => "Durchsuchen",
     "upload_file" => "Datei hochladen"
 ];

--- a/resources/lang/de/folderselect.php
+++ b/resources/lang/de/folderselect.php
@@ -1,0 +1,2 @@
+<?php
+return ["change_folder" => "Ordner wechseln", "select_folder" => "Ordner auswählen"];

--- a/resources/lang/en/browser.php
+++ b/resources/lang/en/browser.php
@@ -2,10 +2,12 @@
 return [
     "cancel" => "Cancel",
     "edit_in_fairu" => "Edit in Fairu",
+    "entries_selected" => "entries selected",
     "new_folder" => "New folder",
     "new_folder_name" => "New foldername",
     "next" => "Next",
     "previous" => "Previous",
     "search_in_folder" => "Search in folder",
+    "select" => "Select",
     "upload" => "Upload"
 ];

--- a/resources/lang/en/browser.php
+++ b/resources/lang/en/browser.php
@@ -1,11 +1,16 @@
 <?php
 return [
     "cancel" => "Cancel",
+    "clear_selection" => "Clear selection",
+    "create" => "Create",
     "edit_in_fairu" => "Edit in Fairu",
     "entries_selected" => "entries selected",
+    "errors" => ["error_fetching_files" => "Error fetching files"],
+    "files_uploaded_successfully" => "Files uploaded successfully.",
     "new_folder" => "New folder",
     "new_folder_name" => "New foldername",
     "next" => "Next",
+    "only_selection" => "Only selection",
     "previous" => "Previous",
     "search_in_folder" => "Search in folder",
     "select" => "Select",

--- a/resources/lang/en/fieldtype.php
+++ b/resources/lang/en/fieldtype.php
@@ -1,8 +1,11 @@
 <?php
 return [
     "change" => "Change",
+    "delete" => "Delete",
     "meta_data_fetching" => "Meta data is being fetched",
+    "open_in_fairu" => "Open in Fairu",
     "or_add_per_drag_and_drop" => "or add by using Drag & Drop.",
+    "rules" => ["max" => "Max", "min" => "Min"],
     "search" => "Search",
     "upload_file" => "Upload file"
 ];

--- a/resources/lang/en/folderselect.php
+++ b/resources/lang/en/folderselect.php
@@ -1,0 +1,2 @@
+<?php
+return ["change_folder" => "Change folder", "select_folder" => "Select folder"];

--- a/resources/lang/fairu.babel
+++ b/resources/lang/fairu.babel
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<babeledit_project be_version="5.3.0" version="1.3">
+<babeledit_project be_version="5.4.1" version="1.3">
 	<!--
 
     BabelEdit project file
@@ -39,6 +39,21 @@
 							</concept_node>
 							<concept_node>
 								<name>edit_in_fairu</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>entries_selected</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -114,6 +129,21 @@
 							</concept_node>
 							<concept_node>
 								<name>search_in_folder</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>select</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -284,6 +314,8 @@
 		</copy_templates>
 		<custom_languages/>
 		<id_extractor_ignores/>
+		<machine_translation_formality>default</machine_translation_formality>
+		<machine_translation_context/>
 	</editor_configuration>
 	<primary_language>en-US</primary_language>
 	<configuration>

--- a/resources/lang/fairu.babel
+++ b/resources/lang/fairu.babel
@@ -38,6 +38,36 @@
 								</translations>
 							</concept_node>
 							<concept_node>
+								<name>clear_selection</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>create</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
 								<name>edit_in_fairu</name>
 								<description/>
 								<comment/>
@@ -54,6 +84,41 @@
 							</concept_node>
 							<concept_node>
 								<name>entries_selected</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<folder_node>
+								<name>errors</name>
+								<children>
+									<concept_node>
+										<name>error_fetching_files</name>
+										<description/>
+										<comment/>
+										<translations>
+											<translation>
+												<language>de-DE</language>
+												<approved>false</approved>
+											</translation>
+											<translation>
+												<language>en-US</language>
+												<approved>false</approved>
+											</translation>
+										</translations>
+									</concept_node>
+								</children>
+							</folder_node>
+							<concept_node>
+								<name>files_uploaded_successfully</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -99,6 +164,21 @@
 							</concept_node>
 							<concept_node>
 								<name>next</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>only_selection</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -213,7 +293,37 @@
 								</translations>
 							</concept_node>
 							<concept_node>
+								<name>delete</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
 								<name>meta_data_fetching</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>open_in_fairu</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -242,6 +352,41 @@
 									</translation>
 								</translations>
 							</concept_node>
+							<folder_node>
+								<name>rules</name>
+								<children>
+									<concept_node>
+										<name>max</name>
+										<description/>
+										<comment/>
+										<translations>
+											<translation>
+												<language>de-DE</language>
+												<approved>false</approved>
+											</translation>
+											<translation>
+												<language>en-US</language>
+												<approved>false</approved>
+											</translation>
+										</translations>
+									</concept_node>
+									<concept_node>
+										<name>min</name>
+										<description/>
+										<comment/>
+										<translations>
+											<translation>
+												<language>de-DE</language>
+												<approved>false</approved>
+											</translation>
+											<translation>
+												<language>en-US</language>
+												<approved>false</approved>
+											</translation>
+										</translations>
+									</concept_node>
+								</children>
+							</folder_node>
 							<concept_node>
 								<name>search</name>
 								<description/>
@@ -259,6 +404,41 @@
 							</concept_node>
 							<concept_node>
 								<name>upload_file</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+						</children>
+					</file_node>
+					<file_node>
+						<name>folderselect</name>
+						<children>
+							<concept_node>
+								<name>change_folder</name>
+								<description/>
+								<comment/>
+								<translations>
+									<translation>
+										<language>de-DE</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>select_folder</name>
 								<description/>
 								<comment/>
 								<translations>
@@ -307,7 +487,7 @@
 		<save_empty_translations>true</save_empty_translations>
 		<translation_order>alphabetically</translation_order>
 		<copy_templates>
-			<copy_template>__('cookienator::%1')</copy_template>
+			<copy_template>__('fairu::%1')</copy_template>
 			<copy_template>{{ __('%1') }}</copy_template>
 			<copy_template>@lang('%1')</copy_template>
 			<copy_template>trans_choice('%1', n)</copy_template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ Route::name('fairu.')
         Route::post('/fairu/upload', [AssetController::class, 'upload'])->name('upload');
         Route::post('/fairu/folders', [AssetController::class, 'folderContent'])->name('folder');
         Route::post('/fairu/folders/create', [AssetController::class, 'createFolder'])->name('folder_create');
+        Route::get('/fairu/folders/{id}', [AssetController::class, 'getFolder'])->name('folder_get');
         Route::post('/fairu/folders/{id}', [AssetController::class, 'updateFolder'])->name('folder_update');
         Route::get('/fairu/files/{id}', [AssetController::class, 'getFile'])->name('file');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,9 +8,12 @@ Route::name('fairu.')
     ->group(function () {
         Route::get('/fairu', [AssetController::class, 'base'])->name('base');
         Route::post('/fairu/upload', [AssetController::class, 'upload'])->name('upload');
+        Route::post('/fairu/upload-multiple', [AssetController::class, 'uploadMultiple'])->name('upload_multiple');
+        Route::post('/fairu/upload-meta-bulk', [AssetController::class, 'uploadMetaBulk'])->name('upload_meta_bulk');
         Route::post('/fairu/folders', [AssetController::class, 'folderContent'])->name('folder');
         Route::post('/fairu/folders/create', [AssetController::class, 'createFolder'])->name('folder_create');
         Route::get('/fairu/folders/{id}', [AssetController::class, 'getFolder'])->name('folder_get');
         Route::post('/fairu/folders/{id}', [AssetController::class, 'updateFolder'])->name('folder_update');
         Route::get('/fairu/files/{id}', [AssetController::class, 'getFile'])->name('file');
+        Route::post('/fairu/files/list', [AssetController::class, 'getFilesList'])->name('files-list');
     });

--- a/src/Fieldtypes/FolderSelector.php
+++ b/src/Fieldtypes/FolderSelector.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Sushidev\Fairu\Fieldtypes;
+
+use Statamic\Fields\Fieldtype;
+
+class FolderSelector extends Fieldtype
+{
+    protected $icon = 'folder-open';
+
+
+    public function preload()
+    {
+        return ['proxy' => config('fairu.url_proxy'), 'file' => config('fairu.url') . '/files'];
+    }
+
+    /**
+     * The blank/default value.
+     *
+     * @return string
+     */
+    public function defaultValue()
+    {
+        return '';
+    }
+
+    /**
+     * Pre-process the data before it gets sent to the publish page.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    public function preProcess($data)
+    {
+        return $data;
+    }
+
+    /**
+     * Process the data before it gets saved.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    public function process($data)
+    {
+        return $data;
+    }
+}

--- a/src/Fieldtypes/fairu.php
+++ b/src/Fieldtypes/fairu.php
@@ -14,6 +14,18 @@ use Statamic\Assets\Asset as AssetsAsset;
 
 class Fairu extends Fieldtype
 {
+    protected $icon = 'addons';
+
+    public $categories = ['media'];
+
+
+    public static $title = 'Fairu Assets';
+
+    public static function handle(): string
+    {
+        return 'fairu';
+    }
+
     public function icon()
     {
         return file_get_contents(__DIR__ . '/../../resources/svg/fairu-favicon.svg');
@@ -43,14 +55,14 @@ class Fairu extends Fieldtype
             return $data;
         }
 
+        if (!is_array($data)) {
+            $data = [$data];
+        }
         if (is_array($data)) {
-
             return collect($data)->map(function ($item) {
-
                 if (Str::isUuid($item)) {
                     return $item;
                 }
-
                 return (new ServicesFairu)->parse($item);
             })->toArray();
         }
@@ -61,6 +73,9 @@ class Fairu extends Fieldtype
 
         return (new ServicesFairu)->parse($data);
     }
+
+
+
 
     public function preload()
     {
@@ -80,19 +95,26 @@ class Fairu extends Fieldtype
      */
     public function process($data)
     {
-        return $data;
+        if (!$data) {
+            return null;
+        }
+
+        return $this->config('max_files') === 1 ? $data[0] : $data;
     }
 
-    protected $icon = 'addons';
-
-    public $categories = ['media'];
-
-
-    public static $title = 'Fairu Assets';
-
-    public static function handle(): string
+    public function rules(): array
     {
-        return 'fairu';
+        $rules = ['array'];
+
+        if ($max = $this->config('max_files')) {
+            $rules[] = 'max:' . $max;
+        }
+
+        if ($min = $this->config('min_files')) {
+            $rules[] = 'min:' . $min;
+        }
+
+        return $rules;
     }
 
     protected function container() {}
@@ -100,6 +122,10 @@ class Fairu extends Fieldtype
     protected function configFieldItems(): array
     {
         return [
+            'section_fairu' => [
+                'display' => 'Fairu',
+                'type' => 'section',
+            ],
             'max_files' => [
                 'display' => 'Max Files',
                 'instructions' => 'Set a maximum number of selectable assets.',
@@ -115,6 +141,11 @@ class Fairu extends Fieldtype
                 'instructions' => '',
                 'type' => 'toggle',
                 'default' => true
+            ],
+            'folder' => [
+                'display' => 'Folder',
+                'instructions' => 'The folder to begin browsing in.',
+                'type' => 'folder_selector',
             ],
         ];
     }

--- a/src/Fieldtypes/fairu.php
+++ b/src/Fieldtypes/fairu.php
@@ -39,34 +39,32 @@ class Fairu extends Fieldtype
      */
     public function preProcess($data)
     {
-        if ($data == null){
+        if ($data == null) {
             return $data;
         }
 
-        if (is_array($data)){
+        if (is_array($data)) {
 
-            return collect($data)->map(function($item){
+            return collect($data)->map(function ($item) {
 
-                if (Str::isUuid($item)){
+                if (Str::isUuid($item)) {
                     return $item;
                 }
 
                 return (new ServicesFairu)->parse($item);
             })->toArray();
-
         }
 
-        if (Str::isUuid($data)){
+        if (Str::isUuid($data)) {
             return $data;
         }
 
         return (new ServicesFairu)->parse($data);
-
     }
 
     public function preload()
     {
-        return ['proxy' => config('fairu.url_proxy')];
+        return ['proxy' => config('fairu.url_proxy'), 'file' => config('fairu.url') . '/files'];
     }
 
     public function getItemData($items)

--- a/src/Http/Controllers/AssetController.php
+++ b/src/Http/Controllers/AssetController.php
@@ -119,4 +119,23 @@ class AssetController extends Controller
 
         return $result->json();
     }
+    public function getFolder(Request $request, String $id)
+    {
+        $connection = config('fairu.connections.default');
+
+        $result = Http::withHeaders([
+            'Tenant' => data_get($connection, 'tenant'),
+            'Authorization' => 'Bearer ' . data_get($connection, 'tenant_secret'),
+        ])->get(config('fairu.url') . '/api/folders/' . $id);
+
+        if ($result->status() == 403) {
+            return abort(403, 'FAIRU: Derzeit exisitert zu diesem Tenant kein Abo. Bitte wende dich an den Support.');
+        }
+
+        if ($result->status() != 200) {
+            return abort(400, 'Fehler bei der Kommunikation mit Fairu.');
+        }
+
+        return $result->json();
+    }
 }

--- a/src/Services/Fairu.php
+++ b/src/Services/Fairu.php
@@ -36,14 +36,15 @@ class Fairu
         return $url;
     }
 
-    public function getFile(?string $id = null): ?array
+    public function getFiles(?array $ids = []): ?array
     {
-        if ($id == null) {
+        if (empty($ids)) {
             return null;
         }
 
-        Log::debug("Request Fairu asset: $id");
-        $result = $this->client->get($this->endpoint('api/files/' . $id));
+        $result = $this->client->post($this->endpoint('api/files/list'), [
+            'ids' => $ids,
+        ]);
 
         if ($result->status() != 200) {
             throw new Exception(json_encode($result?->json()));
@@ -95,6 +96,7 @@ class Fairu
 
     public function parse(string|array $str)
     {
+        ray($str);
         if (is_array($str)) {
             return array_map(function ($strItem) {
                 if (Str::isUuid($strItem)) {
@@ -112,7 +114,7 @@ class Fairu
         return $this->resolveOldAssetPath($str);
     }
 
-    protected function resolveOldAssetPath(?string $value = null): ?string
+    public function resolveOldAssetPath(?string $value = null): ?string
     {
 
         if ($value == null) {


### PR DESCRIPTION
## Support for multiple images
This PR adds the possibility to define `max_files`. If `max_files` is `1`, only one file can be selected. Else, the new image picker in fairu-addon browser is visible to add multiple files.

## New functionality
- [x] Uploading inside browser is buggy
- [x] max_files & min_files should be evaluated properly using validation
- [x] Default folder config
- [x] Multi-upload for multiple files (?)
- [x] Translations
- [x] Statamic Fairu Tags Update

## Screenshots

![CleanShot 2025-04-06 at 16 34 47](https://github.com/user-attachments/assets/26ca5743-6d2b-4803-9078-c81c4c6d428f)

![CleanShot 2025-04-06 at 16 34 59](https://github.com/user-attachments/assets/dd27ab36-2700-485a-887f-64d4ee50484a)

https://github.com/user-attachments/assets/96764d3f-0bf9-4d16-949e-03657a9204f6


