### PR TITLE
fix(upload): return null on failed uploads instead of reading undefined result

### DIFF
--- a/src/Services/Fairu.php
+++ b/src/Services/Fairu.php
@@ -234,26 +234,36 @@ class Fairu
 
     public function uploadFile(string $content, string $filename, ?string $folder): ?string
     {
-        $id = null;
         $uploadLink = $this->createUploadLink($filename, $folder);
+        $uploadUrl = data_get($uploadLink, 'upload_url');
+
+        // No usable upload link (GraphQL error or empty response) — bail out
+        // instead of sending a PUT to a null URL.
+        if (empty($uploadUrl)) {
+            Log::error('Error while uploading ' . $filename . ': no upload URL returned');
+
+            return null;
+        }
 
         try {
-
             $resultUpload = Http::withHeaders([
                 'x-amz-acl'    => 'public-read',
                 'Content-Type' => data_get($uploadLink, 'mime'),
-            ])->send('PUT', data_get($uploadLink, 'upload_url'), [
+            ])->send('PUT', $uploadUrl, [
                 'body' => $content,
             ]);
         } catch (Throwable $ex) {
-            Log::error('Error while uploading ' . $filename);
+            Log::error('Error while uploading ' . $filename . ': ' . $ex->getMessage());
+
+            return null;
         }
 
-        if ($resultUpload->status() == 200) {
-            Http::get(data_get($uploadLink, 'sync_url'));
-            $id = data_get($uploadLink, 'id');
+        if ($resultUpload->status() != 200) {
+            return null;
         }
 
-        return $id;
+        Http::get(data_get($uploadLink, 'sync_url'));
+
+        return data_get($uploadLink, 'id');
     }
 }

--- a/src/Services/Fairu.php
+++ b/src/Services/Fairu.php
@@ -234,7 +234,14 @@ class Fairu
 
     public function uploadFile(string $content, string $filename, ?string $folder): ?string
     {
-        $uploadLink = $this->createUploadLink($filename, $folder);
+        try {
+            $uploadLink = $this->createUploadLink($filename, $folder);
+        } catch (Throwable $ex) {
+            Log::error('Error while uploading ' . $filename . ': ' . $ex->getMessage());
+
+            return null;
+        }
+
         $uploadUrl = data_get($uploadLink, 'upload_url');
 
         // No usable upload link (GraphQL error or empty response) — bail out
@@ -259,6 +266,8 @@ class Fairu
         }
 
         if ($resultUpload->status() != 200) {
+            Log::error('Error while uploading ' . $filename . ': upload responded with status ' . $resultUpload->status());
+
             return null;
         }
 

--- a/src/Services/Fairu.php
+++ b/src/Services/Fairu.php
@@ -271,7 +271,19 @@ class Fairu
             return null;
         }
 
-        Http::get(data_get($uploadLink, 'sync_url'));
+        try {
+            $resultSync = Http::get(data_get($uploadLink, 'sync_url'));
+        } catch (Throwable $ex) {
+            Log::error('Error while uploading ' . $filename . ': sync failed: ' . $ex->getMessage());
+
+            return null;
+        }
+
+        if (! $resultSync->successful()) {
+            Log::error('Error while uploading ' . $filename . ': sync responded with status ' . $resultSync->status());
+
+            return null;
+        }
 
         return data_get($uploadLink, 'id');
     }

--- a/tests/Services/UploadFileTest.php
+++ b/tests/Services/UploadFileTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Sushidev\Fairu\Services\Fairu;
+
+/**
+ * Regression cover for uploadFile(). The PUT result was previously read
+ * outside the try/catch scope, so any thrown request (or a missing upload
+ * URL) surfaced as "Undefined variable $resultUpload" instead of a clean
+ * null return. Every failure path must now return null without touching an
+ * undefined variable.
+ */
+
+const UPLOAD_URL = 'https://upload.example/put/object';
+const SYNC_URL = 'https://sync.example/sync/object';
+const FILE_ID = '22222222-2222-2222-2222-222222222222';
+
+function fakeUploadLink(): array
+{
+    return [
+        'data' => [
+            'createFairuUploadLink' => [
+                'id' => FILE_ID,
+                'mime' => 'image/webp',
+                'upload_url' => UPLOAD_URL,
+                'sync_url' => SYNC_URL,
+            ],
+        ],
+    ];
+}
+
+it('returns the file id and triggers sync on a successful upload', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(fakeUploadLink()),
+        UPLOAD_URL => Http::response('', 200),
+        SYNC_URL => Http::response('', 200),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBe(FILE_ID);
+    Http::assertSent(fn ($request) => $request->url() === SYNC_URL);
+});
+
+it('returns null and skips the PUT when no upload URL is returned', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(['data' => ['createFairuUploadLink' => []]]),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+    Http::assertNotSent(fn ($request) => $request->method() === 'PUT');
+});
+
+it('returns null when the upload request throws instead of raising undefined variable', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(fakeUploadLink()),
+        UPLOAD_URL => fn () => throw new ConnectionException('connection reset'),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+});
+
+it('returns null when the upload responds with a non-200 status', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(fakeUploadLink()),
+        UPLOAD_URL => Http::response('forbidden', 403),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+    Http::assertNotSent(fn ($request) => $request->url() === SYNC_URL);
+});

--- a/tests/Services/UploadFileTest.php
+++ b/tests/Services/UploadFileTest.php
@@ -54,6 +54,16 @@ it('returns null and skips the PUT when no upload URL is returned', function () 
     Http::assertNotSent(fn ($request) => $request->method() === 'PUT');
 });
 
+it('returns null when creating the upload link throws', function () {
+    Http::fake([
+        'fairu.app/graphql' => fn () => throw new ConnectionException('connection reset'),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+});
+
 it('returns null when the upload request throws instead of raising undefined variable', function () {
     Http::fake([
         'fairu.app/graphql' => Http::response(fakeUploadLink()),

--- a/tests/Services/UploadFileTest.php
+++ b/tests/Services/UploadFileTest.php
@@ -75,6 +75,30 @@ it('returns null when the upload request throws instead of raising undefined var
     expect($id)->toBeNull();
 });
 
+it('returns null when the sync request responds with an error status', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(fakeUploadLink()),
+        UPLOAD_URL => Http::response('', 200),
+        SYNC_URL => Http::response('sync failed', 500),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+});
+
+it('returns null when the sync request throws', function () {
+    Http::fake([
+        'fairu.app/graphql' => Http::response(fakeUploadLink()),
+        UPLOAD_URL => Http::response('', 200),
+        SYNC_URL => fn () => throw new ConnectionException('connection reset'),
+    ]);
+
+    $id = (new Fairu())->uploadFile('bytes', 'hero.webp', null);
+
+    expect($id)->toBeNull();
+});
+
 it('returns null when the upload responds with a non-200 status', function () {
     Http::fake([
         'fairu.app/graphql' => Http::response(fakeUploadLink()),


### PR DESCRIPTION
## Problem

`Fairu::uploadFile()` read the PUT response (`$resultUpload`) outside the `try/catch` scope. When the upload request threw (network error) or the upload link was empty (`upload_url` null), execution fell through to `$resultUpload->status()` on an unassigned variable, surfacing as:

```
ErrorException: Undefined variable $resultUpload
  at src/Services/Fairu.php:201
```

This masked the real cause (failed upload / missing upload link) and, for consumers that retry on failure, produced repeated misleading error reports.

## Fix

- Guard an empty `upload_url` → return `null` instead of sending a PUT to a null URL
- `return null` from the `catch` (with the exception message logged) instead of continuing to an undefined variable
- Only hit `sync_url` and return the id on a 200 response

## Tests

New `tests/Services/UploadFileTest.php` covers success, empty upload link, thrown PUT, and non-200. Verified red before the change (both failure paths threw the exact `Undefined variable $resultUpload` error) and green after. Full suite: 9 passed.